### PR TITLE
Version 1.0.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - python
     - setuptools
     - wheel
+    - hatchling
   run:
     - python
     - h11 >=0.11,<0.13

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,9 @@ build:
   skip: True  # [py<38 or s390x]
 
 requirements:
+  build:
+    - patch  # [unix]
+    - m2-patch  # [win]
   host:
     - pip
     - python
@@ -42,6 +45,9 @@ about:
   license_family: BSD
   license_file: LICENSE.md
   summary: The next generation HTTP client.
+  description: The HTTP Core package provides a minimal low-level HTTP client, which does one thing only. Sending HTTP requests.
+  dev_url: https://github.com/encode/httpcore
+  doc_url: https://www.encode.io/httpcore/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
 
 build:
   number: 0
-  script: '{{ PYTHON }} -m pip install . -vv '
-  skip: True  # [py<36 or s390x]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<38 or s390x]
 
 requirements:
   host:
@@ -23,11 +23,8 @@ requirements:
     - hatchling
   run:
     - python
-    - h11 >=0.11,<0.13
-    - h2 >=3,<5
-    - sniffio ==1.*
-    - anyio ==3.*
     - certifi
+    - h11 >=0.13,<0.15
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "httpcore" %}
-{% set version = "0.15.0" %}
+{% set version = "1.0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 18b68ab86a3ccf3e7dc0f43598eaddcf472b602aba29f9aa6ab85fe2ada3980b
+  sha256: 9fc092e4799b26174648e54b74ed5f683132a464e95643b226e00c2ed2fa6535
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 9fc092e4799b26174648e54b74ed5f683132a464e95643b226e00c2ed2fa6535
+  patches:
+    - patches/0001-remove-fancy-pypi-readme.patch
 
 build:
   number: 0
@@ -32,8 +34,7 @@ test:
   imports:
     - httpcore
   commands:
-    - pip check || true  # [not win]
-    - pip check || 1     # [win]
+    - pip check
 
 about:
   home: https://github.com/encode/httpcore

--- a/recipe/patches/0001-remove-fancy-pypi-readme.patch
+++ b/recipe/patches/0001-remove-fancy-pypi-readme.patch
@@ -1,0 +1,36 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 719fb18..603d980 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["hatchling", "hatch-fancy-pypi-readme"]
++requires = ["hatchling"]
+ build-backend = "hatchling.build"
+ 
+ [project]
+@@ -63,15 +63,6 @@ include = [
+     "/tests"
+ ]
+ 
+-[tool.hatch.metadata.hooks.fancy-pypi-readme]
+-content-type = "text/markdown"
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-path = "README.md"
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-path = "CHANGELOG.md"
+-
+ [tool.mypy]
+ strict = true
+ show_error_codes = true
+@@ -96,7 +87,7 @@ filterwarnings = ["error"]
+ 
+ [tool.coverage.run]
+ omit = [
+-    "venv/*", 
++    "venv/*",
+     "httpcore/_sync/*"
+ ]
+ include = ["httpcore/*", "tests/*"]


### PR DESCRIPTION
httpcore 1.0.2

**Destination channel:** defaults

### Links

- [PKG-3954](https://anaconda.atlassian.net/browse/PKG-3954)
- [Upstream repository](https://github.com/encode/httpcore)
- [Upstream changelog/diff](https://github.com/encode/httpcore/blob/master/CHANGELOG.md)
- Relevant dependency PRs:
  - [PKG-3953](https://anaconda.atlassian.net/browse/PKG-3953)

### Explanation of changes:

- Update version and dependencies
- Add patch to remove `hatch-fancy-pypy-readme`
- Reinstate `pip check`
- Linter fixes


[PKG-3954]: https://anaconda.atlassian.net/browse/PKG-3954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-3953]: https://anaconda.atlassian.net/browse/PKG-3953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ